### PR TITLE
Fix latex link error

### DIFF
--- a/chapter2.tex
+++ b/chapter2.tex
@@ -123,7 +123,7 @@ source /opt/ros/@@indigo@@/setup.bash
 
   青色の文字を利用したいバージョンに変更すれば、複数のバージョンのROSを切り替えて利用できる。
 
- ※Ubuntuのバージョンが利用したいROSバージョンをサポートしている時のみ可能。\textbf{\ref{section:xxxxx}}項参照のこと。
+ ※Ubuntuのバージョンが利用したいROSバージョンをサポートしている時のみ可能。\textbf{\ref{section:rosversion}項参照のこと。
 \end{exercise}
 
 \subsubsection{rosdepの初期化}


### PR DESCRIPTION
Fix linked reference on this page.
It seems temporal characters (section:xxxxxx) in original file.